### PR TITLE
added a script for starting containerized server serving files

### DIFF
--- a/startServer.sh
+++ b/startServer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker run -p 80:80/tcp --rm --name petdisk -v $(pwd)/www:/var/www/html php:7.4-apache
+


### PR DESCRIPTION
Just a simple script for starting a container with preconfigured apache and php running petdisk.php for people who don't want to install a http server and php on their computers. Simply copy files to the www, run "./startServer.sh" and that's it.